### PR TITLE
Week04 BOJ 6603 로또

### DIFF
--- a/heeheej/week04/BOJ_6603.py
+++ b/heeheej/week04/BOJ_6603.py
@@ -1,0 +1,24 @@
+# 로또
+# 176ms, 115272kb
+# 조합을 이용한다.
+
+import sys
+from itertools import combinations
+
+sys.stdin = open("input.txt", "r", encoding = "UTF-8")
+input = sys.stdin.readline
+
+while True:
+    inputs = list(map(int, input().split()))
+    k = inputs[0]
+    if k == 0:
+        break
+    inputs = inputs[1:]
+
+    nums = [i for i in range(k)]
+    combs = combinations(nums, 6)
+    for comb in combs:
+        for i in comb:
+            print(inputs[i], end=' ')
+        print()
+    print()


### PR DESCRIPTION
# BOJ 6603: 로또

- 메모리: 115272KB
- 시간 : 176ms

## 🚩 설계

조합을 이용한다.