### PR TITLE
Week09 BOJ 2166 다각형의 면적

### DIFF
--- a/heeheej/week09/BOJ_2166.py
+++ b/heeheej/week09/BOJ_2166.py
@@ -1,0 +1,24 @@
+# 다각형의 면적
+# 125ms, 114976kb
+# 수학 문제
+# 다각형의 넓이 공식(신발끈 공식)을 사용한다.
+
+import sys
+
+sys.stdin = open("input.txt", "r")
+input = sys.stdin.readline
+
+N = int(input())
+point = [tuple(map(int, input().split())) for _ in range(N)]
+point.append(point[0])
+
+
+def getArea(arr):
+    area = 0
+    for i in range(N):
+        area += arr[i][0] * arr[i + 1][1] - arr[i + 1][0] * arr[i][1]
+    area = abs(area) * 0.5
+    return area
+
+
+print(getArea(point))


### PR DESCRIPTION
# BOJ 2166: 다각형의 면적

- 메모리: 114976kb
- 시간 : 125ms

## 🚩 설계
수학 문제
다각형의 넓이 공식(신발끈 공식)을 사용한다.
https://ko.wikipedia.org/wiki/%EC%8B%A0%EB%B0%9C%EB%81%88_%EA%B3%B5%EC%8B%9D
![image](https://user-images.githubusercontent.com/64790176/233248329-96bb6cdc-7666-4104-839d-92bd118b1422.png)

