### PR TITLE
Week01_1 BOJ 17281 야구

### DIFF
--- a/KangHyojin1401/week01/BOJ_17281.java
+++ b/KangHyojin1401/week01/BOJ_17281.java
@@ -1,0 +1,106 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+
+	static int N;
+	static int[][] player;
+	static int maxScore = Integer.MIN_VALUE; //최대 점수
+	static boolean[] base = new boolean[3]; //1루, 2루, 3루
+
+	static int[] selected = new int[9]; //순열 뽑을 때
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		//초기화
+		N = Integer.parseInt(br.readLine()); //이닝 수
+		player = new int[N][];
+
+		for (int i = 0; i < N; i++) {
+			player[i] = new int[9];
+			String[] line = br.readLine().split(" ");
+
+			for (int j = 0; j < 9; j++) {
+				player[i][j] = Integer.parseInt(line[j]);
+			}
+		}
+
+		perm(0, 1<<0); //1번 선수 자리 고정
+
+
+		//출력
+		bw.write(maxScore + "\n");
+		bw.flush();
+		bw.close();
+		br.close();
+
+	}
+
+	static void perm(int cnt, int flag) {
+		if (cnt == 9) { //타순 정해졌으면
+			int score = 0; //총 점수
+			int j = 0;
+
+			for (int i = 0; i < N; i++) { //N이닝동안
+				int outCount = 0; //이닝 당 아웃카운트
+				base = new boolean[3];
+
+				while (outCount != 3) {
+					int result = player[i][selected[j]]; //정해진 공격 실행
+
+					if (result == 0) { //아웃일 경우
+						outCount++;
+					} else { //1, 2, 3루타, 홈런
+						//주자
+						for (int k = 2; k >= 0; k--) {
+							if (base[k]) { //루상에 주자가 있어야 하고
+								if ((k + 1) + result > 3) { //주자가 위치한 루 + 타자의 루타 > 3 이면 득점
+									score++;
+								} else { //아니면 그냥 진루
+									base[k + result] = true;
+								}
+								base[k] = false;
+							}
+						}
+
+						//타자
+						if (result == 4) {
+							score++;
+						} else {
+							base[result - 1] = true;
+						}
+					}
+
+					if (++j == 9) { //한바퀴 돌면 0으로 다시 돌려줌
+						j = 0;
+					}
+				}
+			}
+
+			if (maxScore < score) {
+				maxScore = score;
+			}
+
+			return;
+		}
+
+		if (cnt == 3) { //1번 선수 -> 4번 타순
+			selected[cnt] = 0;
+			perm(cnt + 1, flag);
+		}
+
+
+		for (int i = 0; i < 9; i++) {
+			if ((flag & 1<<i) == 0) {
+				selected[cnt] = i;
+				perm(cnt + 1, flag | 1<<i);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
# BOJ 17281: ⚾

- 메모리: 63484 KB
- 시간 : 516 ms

## 🚩 설계
일단 완탐 돌리자.
완탐 하면 8! = 약 40,000번. 
	         40,000 * 50이닝 = 2,000,000 (2백만)

```java
/*
* 1. 먼저 타순 배치를 한다. 완탐으로 (같은 숫자일 때 중복이 많이 발생할 거 같긴 한데 이걸 어케 하는지 모르겠다.)
* 2. N번 돌면서 계산을 한다.
* 	2-1. 1 => 타자와 모든 주자가 한 루씩 진루
*  2-2. 2 => 타자와 모든 주자가 두 루씩 진루
*  2-3. 3 => 타자와 모든 주자가 세 루씩 진루
*  2-4. 4 => 타자와 모든 주자가 홈까지 진루
*  2-5. 0 => 모든 주자는 진루하지 못하고, 공격 팀에 아웃이 하나 증가
* 3. 최대 점수 갱신을 한다.
*/
``` 

문제를 풀 때 접근한 방식

## ✅ 후기
1. 선수 고정하는 거(순열에서 자리 고정)

2. 주자들 진루시킬 때 
```java
for (int k = 2; k >= 0; k--) {
  if (base[k]) { //루상에 주자가 있어야 하고
    if ((k + 1) + result > 3) { //주자가 위치한 루 + 타자의 루타 > 3 이면 득점
	    score++;
    } else { //아니면 그냥 진루
	    base[k + result] = true;
    }
    base[k] = false;
  }
}
``` 
처음에는 for (int k = 0; k < 3; k++) 이렇게 함.
그랬더니 base[k + result] = true;로 변경했을 때, k가 증가함에 따라 원래는 base[k]가 false여야 되는 게 true로 나오는 문제가 있었다.
그래서 인덱스를 뒤부터 해서 주자를 진루시켰다.