### PR TITLE
Week11 BOJ 19598 최소 회의실 개수

### DIFF
--- a/heeheej/week11/BOJ_19598.py
+++ b/heeheej/week11/BOJ_19598.py
@@ -1,0 +1,23 @@
+# 최소 회의실 개수
+# 126708kb, 492ms
+
+import sys, heapq
+
+sys.stdin = open("input.txt", "r")
+input = sys.stdin.readline
+
+N = int(input())
+time = [tuple(map(int, input().split())) for _ in range(N)]
+time.sort()
+q = []
+heapq.heappush(q, time[0][1])   # 회의 시작 시간이 가장 빠른 회의가 끝나는 시간을 q라는 힙큐에 넣는다.
+time.pop(0)
+cnt = 1
+for start, end in time:
+    if q[0] <= start:
+        heapq.heappop(q)
+    else:
+        cnt += 1
+    heapq.heappush(q, end)
+
+print(cnt)


### PR DESCRIPTION
# BOJ 19598: 최소 회의실 개수

- 메모리: 126708kb
- 시간 : 492ms

## 🚩 설계
강의실 문제와 똑같은 코드로 풀 수 있는데,
힙큐를 하나만 쓰고 반복문 돌려서 풀면 더 빠르다.
