### PR TITLE
Week21 PRG 42577 전화번호 목록

### DIFF
--- a/heeheej/week21/PRG_42577_전화번호_목록.py
+++ b/heeheej/week21/PRG_42577_전화번호_목록.py
@@ -1,0 +1,17 @@
+# 전화번호 목록
+# 프로그래머스 코딩테스트 고득점 kit > 해시
+# 1172 (+13)
+# 왜 해시 문제인지 모르겠다.. 정렬과 슬라이싱 이용해 풀이
+
+from collections import defaultdict
+
+def solution(phone_book):
+    answer = True
+    phone_book.sort()
+    N = len(phone_book)
+    for i in range(N-1):
+        val = phone_book[i]
+        if val == phone_book[i+1][:len(val)]:
+            answer = False
+            break
+    return answer


### PR DESCRIPTION
# PRG 42577 전화번호 목록

- 메모리: KB
- 시간 : ms

## 🚩 설계
- 프로그래머스 코딩테스트 고득점 kit > 해시
- 1172 (+13)
- 왜 해시 문제인지 모르겠다.. 
- 정렬과 슬라이싱 이용해 풀이
     - phone_book을 사전순으로 정렬하고, for문을 돌면서 현재 전화번호가 다음 전화번호의 접두어인지 확인하고 맞으면 False처리해준다. 
     - 사전순으로 정렬했으므로 뒷 순서의 전화번호들 중 가장 접두어일 확률이 높은 전화번호는 다음 순서의 전화번호이며, 이 전화번호가 접두어가 아니라면 뒷 순서는 확인해 볼 필요도 없다.