### PR TITLE
Week24 PRG 42746 가장 큰 수

### DIFF
--- a/heeheej/week24/PRG_42746_가장_큰_수.py
+++ b/heeheej/week24/PRG_42746_가장_큰_수.py
@@ -1,0 +1,11 @@
+# 가장 큰 수
+# 프로그래머스 코딩테스트 고득점 kit > 정렬
+# 1231 (+12)
+# https://yuna0125.tistory.com/145 참고
+
+def solution(numbers):
+    answer = ''
+    numbers = [str(x) for x in numbers]
+    numbers.sort(key = lambda x : x*3, reverse = True)
+    answer = str(int(''.join(numbers)))
+    return answer


### PR DESCRIPTION
# PRG 42746 가장 큰 수

## 🚩 설계
- 프로그래머스 코딩테스트 고득점 kit > 정렬
- 1231 (+12)
- 숫자를 사전순으로 정렬을 한다고 생각했을 때, 자리수가 다른 친구들(ex. 30과 3)을 비교해주기 위해 아이디어가 필요하다.
   "30"이라는 문자열에 세번 반복해(곱하기 3) "303030", "3"이라는 문자열을 세번 반복해 "333"을 만든다.
   3이 30보다 앞서야 하는데, 이렇게 반복시키면 사전순으로 정렬했을 때 알맞게 정렬된다.
   - 세번 반복, 즉 문자열*3을 해줘야 하는 이유는, 주어진 조건에 각 원소가 0이상 1000=10^3이하라고 했기 때문이다.
   자리수가 한자리인 경우에도 세번까지만 반복하면 자리수가 세자리인 수 + 1000과 비교가 가능해진다.
   - 마지막에 int으로 변환 후 str로 변환하는 이유는, 변환하지 않으면 numbers = [0, 0, 0]인 경우 "000"이라는 문자열이 만들어지게 되므로 이를 0으로 바꿔주어야하기 때문! 그리고 문제에서 결과의 기댓값을 문자열로 반환하기를 원했기 때문에 다시 str로 변환해준다.